### PR TITLE
Update documentation for MCJIT to ORC JIT migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.0] - 2025-10-17
+
+### Major Infrastructure Upgrade
+- **MCJIT to ORC JIT Migration**: Complete replacement of deprecated MCJIT with modern LLVM ORC JIT
+  - Migrated from `ExecutionEngine` to `LLJIT` (LLVM 18 ORC JIT infrastructure)
+  - Updated symbol registration from `addGlobalMapping()` to `SymbolMap` with `ExecutorSymbolDef`
+  - Enhanced memory management with `ThreadSafeModule` support
+  - Added `releaseContext()` method to codegen for proper context handling
+  - Comprehensive symbol registration for standard library functions (`malloc`, `free`, `memset`)
+  - Proper handling of mangled symbol names with variants (.1, .2, etc.)
+
+### Fixed
+- **Segmentation Fault Resolution**: Completely resolved segmentation faults in Vec system memory management
+  - Fixed crashes occurring during JIT execution of functions with malloc/free operations
+  - ORC JIT provides better isolation between JIT memory and application memory
+  - Vec system memory management now works perfectly with multiple object creation and cleanup
+  - Proven through comprehensive testing with multiple Vec creation scenarios
+
+### Improved
+- **JIT Performance**: Modern ORC JIT provides better performance and stability
+- **Memory Safety**: Enhanced separation between compiler memory and runtime memory
+- **Function Execution**: Robust function pointer conversion using `ExecutorAddr` API
+- **Symbol Resolution**: Better handling of runtime symbol lookup and registration
+
+### Technical Details
+- **New LLVM Headers**: 
+  - `llvm/ExecutionEngine/Orc/LLJIT.h`
+  - `llvm/ExecutionEngine/Orc/ThreadSafeModule.h`
+  - `llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h`
+- **Updated Function Lookup**: Replaced `FindFunctionNamed()` with `jit->lookup()` pattern
+- **Enhanced Symbol Registration**: `ExecutorAddr::fromPtr()` for proper symbol mapping
+- **Memory Function Support**: Full registration of malloc/free/memset with proper mangling
+
+### Migration Impact
+- **Developer Experience**: No changes to Vyn language syntax or semantics
+- **Runtime Stability**: Dramatically improved stability for memory-intensive operations
+- **Vec System**: Full functionality restored with automatic cleanup working perfectly
+- **Performance**: Better JIT compilation performance with modern LLVM infrastructure
+
+### Test Results
+- **Memory Safety**: Multiple Vec creation and destruction without crashes
+- **Function Calls**: Complex function call chains with malloc/free operations
+- **Return Values**: Proper exit code handling and complex return type serialization
+- **Compilation**: Faster and more reliable JIT compilation process
+
+### Files Modified
+- `src/main.cpp` - Complete MCJIT to ORC JIT conversion with symbol registration
+- `include/vyn/vre/llvm/codegen.hpp` - Added ThreadSafeModule support methods
+- Standard library integration remains unchanged, maintaining API compatibility
+
+---
+
 ## [0.3.6] - 2025-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -746,6 +746,10 @@ unsafe {
 ## Roadmap
 
 ### ✅ **Completed (v0.4.0)**
+- **JIT Infrastructure Upgrade**: Migrated from deprecated MCJIT to modern LLVM ORC JIT
+  - Resolved all segmentation faults in Vec system memory management
+  - Enhanced stability and performance for memory-intensive operations
+  - Better isolation between JIT compilation memory and application memory
 - **Complete Core Language**: Functions, variables, structs with modern `field<Type>` syntax
 - **LLVM Backend**: Full compilation pipeline with JIT execution
 - **Advanced Control Flow**: `if/else`, `while/for` loops, `match` statements, `break/continue`
@@ -777,9 +781,9 @@ Vyn is built on solid foundations:
 
 - **Frontend**: Hand-written recursive descent parser
 - **AST**: Rich abstract syntax tree with source location tracking
-- **Backend**: LLVM for code generation and JIT execution
+- **Backend**: LLVM for code generation and ORC JIT execution
 - **Type System**: Strong static typing with ownership and borrowing
-- **Runtime**: LLVM ExecutionEngine with auto-serialization support
+- **Runtime**: LLVM ORC JIT (LLJIT) with auto-serialization support
 
 ## Contributing
 

--- a/doc/RUNTIME.md
+++ b/doc/RUNTIME.md
@@ -10,6 +10,8 @@ Vyn's memory model is designed for safety and explicitness, drawing inspiration 
 
 This document details these aspects, aligning with the `mem_RFC.md` proposal.
 
+**Runtime Note**: As of v0.4.0, Vyn uses LLVM's modern ORC JIT infrastructure, providing robust memory management and excellent compatibility with the ownership and borrowing system described here.
+
 ## 2. Variable Declarations and Binding Mutability
 
 Vyn uses two keywords for variable bindings:


### PR DESCRIPTION
- Add comprehensive v0.4.0 changelog entry documenting JIT infrastructure upgrade
- Update README architecture section to reflect ORC JIT usage
- Add ORC JIT compatibility note to RUNTIME.md
- Document resolution of Vec system segmentation faults
- Update roadmap to reflect completed infrastructure improvements