### PR TITLE
Fix Self substitution in type parameter bound method returns

### DIFF
--- a/src/vre/semantic.cpp
+++ b/src/vre/semantic.cpp
@@ -988,10 +988,19 @@ void SemanticAnalyzer::visit(ast::CallExpression* node) {
                                             std::cout << "DEBUG: CallExpression: Type parameter " << typeNameStr 
                                                       << " with bound " << boundName 
                                                       << " allows method " << methodName << std::endl;
-                                            // Found the method in bounds - allow it
+                                            // Found the method in bounds - substitute Self with type parameter
                                             if (method.returnType) {
-                                                expressionTypes[node] = method.returnType;
-                                                node->type = std::shared_ptr<ast::TypeNode>(method.returnType->clone());
+                                                // Check if return type is Self - if so, replace with type parameter
+                                                ast::TypeNode* actualReturnType = method.returnType;
+                                                if (auto returnTypeName = dynamic_cast<ast::TypeName*>(method.returnType)) {
+                                                    if (returnTypeName->identifier && returnTypeName->identifier->name == "Self") {
+                                                        // Return Self -> substitute with type parameter
+                                                        actualReturnType = typeName; // The type parameter itself
+                                                        std::cout << "DEBUG: Substituting Self return type with type parameter " << typeNameStr << std::endl;
+                                                    }
+                                                }
+                                                expressionTypes[node] = actualReturnType;
+                                                node->type = std::shared_ptr<ast::TypeNode>(actualReturnType->clone());
                                             }
                                             return;
                                         }


### PR DESCRIPTION
When calling a bound method on a type parameter (e.g., T.clone()), the return type Self now correctly resolves to the type parameter T.

Example:
  bind<T<Clone>> { T.clone() returns T, not Self }

Progress: 8 errors → 7 errors