### PR TITLE
FREEDOM BLOCKS: Replace 'unsafe' keyword with 'freedom'

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ build/vyn tuple.vyn  # Outputs: [42, "Hello!"]
 *   **Borrowing**:
     *   `view(expr)`: Creates an immutable borrow `their<T const>`.
     *   `borrow(expr)`: Creates a mutable borrow `their<T>`.
-*   **`unsafe` Blocks**: Sections of code marked `unsafe { ... }` where raw pointers (`loc<T>`) can be used and some compiler guarantees are relaxed. Within these blocks, operations like `at(ptr)` for dereferencing and `from<loc<T>>()` for pointer conversion are available.
+*   **`freedom` Blocks**: Sections of code marked `freedom { ... }` where raw pointers (`loc<T>`) can be used and some compiler guarantees are relaxed. Within these blocks, operations like `at(ptr)` for dereferencing and `from<loc<T>>()` for pointer conversion are available.
 *   **Scoped Block**: Planned block prefixed with `scoped` that defers GC and cleans up at block exit.
 *   **Actor**: Planned lightweight concurrent entity with a built-in mailbox for message passing.
 *   **Tiered JIT**: Planned two-level execution—bytecode interpreter for startup, optimized native JIT for hot code.
@@ -370,7 +370,7 @@ main()<Int> -> {
 | `my<T>` | Unique ownership | Single owner, move semantics | `data<my<Person>> = my(Person{...})` |
 | `our<T>` | Shared ownership | Reference counting | `config<our<Settings>> = our(Settings{...})` |
 | `their<T>` | Borrowed reference | Non-owning access | `ref<their<Data>> = view(owner)` |
-| `loc<T>` | Raw pointer | Unsafe operations only | `ptr<loc<Int>> = loc(variable)` |
+| `loc<T>` | Raw pointer | Freedom operations only | `ptr<loc<Int>> = loc(variable)` |
 
 ### ✅ **Canonical Ownership Syntax** 
 
@@ -417,8 +417,8 @@ python3 migrate_syntax.py --migrate --directory . --backup --report
 ### ✅ **Memory Management**
 - **Ownership types**: `my<T>`, `our<T>`, `their<T>` for safe memory handling
 - **Borrowing**: `view(expr)` and `borrow(expr)` for references  
-- **Unsafe operations**: `loc<T>` pointers in `unsafe {}` blocks
-- **Raw Memory Operations**: Complete `unsafe` block system with `loc<T>` pointers
+- **Freedom operations**: `loc<T>` pointers in `freedom {}` blocks
+- **Raw Memory Operations**: Complete `freedom` block system with `loc<T>` pointers
 - **Memory Safety**: Borrow checking and lifetime analysis prevent dangling pointers
 - **Hybrid Model**: Combines ownership with planned GC for maximum flexibility
 
@@ -510,7 +510,7 @@ main()<Int> -> {
 }
 ```
 
-### Memory Safety & Unsafe Operations
+### Memory Safety & Freedom Operations
 
 Vyn's design philosophy emphasizes safety by default, but provides escape hatches for low-level memory manipulation when needed:
 
@@ -531,12 +531,12 @@ safe_memory_example()<Int> -> {
     return 42
 }
 
-# Unsafe operations for low-level control
+# Freedom operations for low-level control
 unsafe_memory_example()<Int> -> {
     x<Int> = 42
     result<Int> = 0
     
-    unsafe {
+    freedom {
         # Create raw pointers
         p<loc<Int>> = loc(x)     # Get pointer to x
         q<loc<Int>> = loc(result) # Get pointer to result
@@ -553,12 +553,12 @@ unsafe_memory_example()<Int> -> {
 }
 ```
 
-**Safety Guidelines for Unsafe Code:**
-1. Minimize the scope of `unsafe` blocks
+**Safety Guidelines for Freedom Code:**
+1. Minimize the scope of `freedom` blocks
 2. Document all invariants and assumptions
 3. Validate pointers before dereferencing
-4. Encapsulate unsafe operations behind safe abstractions
-5. Test unsafe code extensively
+4. Encapsulate freedom operations behind safe abstractions
+5. Test freedom code extensively
 
 ### Syntax and Literals
 
@@ -652,7 +652,7 @@ borrowed<their<String>> = borrow(safe_data)  # Non-owning reference
 - **Dynamic arrays**: `Vec<T>` resizable collections
 - **Tuples**: `Tuple<T,U,...>` variadic heterogeneous types
 
-**Ownership Types**: `my<T>` (unique), `our<T>` (shared), `their<T>` (borrowed), `loc<T>` (unsafe raw pointer)
+**Ownership Types**: `my<T>` (unique), `our<T>` (shared), `their<T>` (borrowed), `loc<T>` (freedom raw pointer)
 
 **Type Aliasing**: All numeric types support multiple naming conventions:
 - Vyn style: `Int32`, `Float64`, `UInt8`
@@ -1513,8 +1513,8 @@ another_ref<our<String>> = shared  # Reference count incremented
 view_ref<their<String>> = view(shared)      # Immutable borrow
 mut_ref<their<String>> = borrow(owned)      # Mutable borrow
 
-# Raw pointers for unsafe operations
-unsafe {
+# Raw pointers for freedom operations
+freedom {
     x<Int> = 42
     ptr<loc<Int>> = loc(x)  # Get pointer to x
     at(ptr) = 99           # Modify through pointer
@@ -1964,7 +1964,7 @@ BorrowExpr             ::= 'borrow' '(' Expression ')'
 - `view(expr)`: Creates `their<T const>` immutable borrow
 - `borrow(expr)`: Creates `their<T>` mutable borrow
 
-**Unsafe Operations:**
+**Freedom Operations:**
 - `loc<T>`: Raw pointer type
 - `loc(expr)`: Get pointer to expression
 - `at(ptr)`: Dereference pointer (read/write)

--- a/TODO.md
+++ b/TODO.md
@@ -23,7 +23,7 @@ Based on comprehensive implementation progress, approximately **50-60%** of core
 - **Expressions**: Binary ops, unary ops, member access, function calls
 - **Pattern matching**: match statements with destructuring
 - **LLVM Integration**: Complete codegen with JIT execution and DWARF debug info
-- **Unsafe blocks**: Full support with semantic validation
+- **Freedom blocks**: Full support with semantic validation
 
 ### Type System (Complete)
 - **Primitive types**: Int, Int8-64, UInt8-64, Float32/64, Bool, Char, Rune, String
@@ -81,9 +81,9 @@ Based on comprehensive implementation progress, approximately **50-60%** of core
   - [ ] LLVM codegen for ownership
 
 #### 4. **Memory Management** ⚠️ CRITICAL  
-- [🔶] **Unsafe blocks** - PARTIALLY IMPLEMENTED
-  - [x] `unsafe { ... }` parsing and tokenization
-  - [ ] Semantic validation (operations only allowed in unsafe)
+- [🔶] **Freedom blocks** - PARTIALLY IMPLEMENTED
+  - [x] `freedom { ... }` parsing and tokenization
+  - [ ] Semantic validation (operations only allowed in freedom)
 - [ ] **Memory intrinsics** - NOT IMPLEMENTED
   - [ ] `loc<T>()` pointer creation intrinsic
   - [ ] `at()` pointer dereferencing intrinsic
@@ -151,7 +151,7 @@ Based on comprehensive implementation progress, approximately **50-60%** of core
 
 ### Active Issues
 - [x] **LLVM Type Mismatches**: Return types show as `i32` instead of actual types *(IN PROGRESS)*
-- [x] **Unsafe Keyword**: ~~Tokenized as `UNKNOWN` instead of `KEYWORD_UNSAFE`~~ *(FIXED - works correctly in function context)*
+- [x] **Freedom Keyword**: ~~Tokenized as `UNKNOWN` instead of `KEYWORD_UNSAFE`~~ *(FIXED - works correctly in function context)*
 - [ ] **Semantic Analysis**: Incomplete type checking and validation
 - [ ] **Error Handling**: Parser error recovery needs improvement
 
@@ -233,7 +233,7 @@ Function return type does not match operand type of return inst!
 - ✅ `test/async/async_comprehensive.vyn` - Async with await expressions
 - ✅ `test/string/*.vyn` - String operations and methods
 - ✅ `examples/binary_tree*.vyn` - Complex data structures
-- ✅ Unsafe blocks with memory operations
+- ✅ Freedom blocks with memory operations
 
 ### Known Issues
 - ⚠️ Generic types fail LLVM codegen (needs Phase 5 monomorphization)

--- a/doc/AST_Core.md
+++ b/doc/AST_Core.md
@@ -125,7 +125,7 @@ enum class NodeType {
     TRY_STATEMENT,
     THROW_STATEMENT,        // Added as per ast.hpp
     SCOPED_STATEMENT,       // Added as per ast.hpp
-    UNSAFE_BLOCK_STATEMENT, // For unsafe memory operations
+    UNSAFE_BLOCK_STATEMENT, // For freedom memory operations
     // PATTERN_ASSIGNMENT_STATEMENT, // Not in ast.hpp, but in roadmap
 
     // Types

--- a/doc/AST_Statements.md
+++ b/doc/AST_Statements.md
@@ -339,12 +339,12 @@ public:
 
 ## 13. `UnsafeBlockStatement`
 
-Represents an unsafe code block where memory operations are allowed.
+Represents an freedom code block where memory operations are allowed.
 
 -   **C++ Class**: `vyn::ast::UnsafeBlockStatement`
 -   **`NodeType`**: `UNSAFE_BLOCK_STATEMENT`
 -   **Fields**:
-    -   `body` (`BlockStatementPtr`): A pointer to the block statement containing the code in the unsafe block.
+    -   `body` (`BlockStatementPtr`): A pointer to the block statement containing the code in the freedom block.
 
 ```cpp
 // From include/vyn/parser/ast.hpp
@@ -359,7 +359,7 @@ public:
 } // namespace vyn::ast
 ```
 
-Unsafe blocks are used to contain low-level memory operations that could be unsafe if used incorrectly. Within an unsafe block, you can:
+Freedom blocks are used to contain low-level memory operations that could be freedom if used incorrectly. Within an freedom block, you can:
 
 1. Create raw pointers with `loc<T>(expr)`
 2. Dereference pointers with `at(ptr)`
@@ -367,13 +367,13 @@ Unsafe blocks are used to contain low-level memory operations that could be unsa
 
 Example:
 ```vyn
-unsafe {
+freedom {
     var<loc<Int>> p = loc(x);
     at(p) = 99;  // Modify the value at the pointer location
     var<Int> q = at(p); // Read the value at the pointer location
 }
 ```
 
-These operations are unsafe because they bypass Vyn's memory safety guarantees, allowing for potential errors like null pointer dereferences, dangling pointers, and memory corruption.
+These operations are freedom because they bypass Vyn's memory safety guarantees, allowing for potential errors like null pointer dereferences, dangling pointers, and memory corruption.
 
 *Note: `PatternAssignmentStatement` is mentioned in `AST_Roadmap.md` but not currently present in `vyn/parser/ast.hpp`'s statement definitions. It will be added here once implemented.*

--- a/doc/AST_Types.md
+++ b/doc/AST_Types.md
@@ -288,7 +288,7 @@ Represents a raw memory location (pointer) of type `T`.
   - `genericType`: `BasicTypeNode` with name "loc"
   - `typeArguments`: A vector containing a single entry of the pointee type `T`
 
-This type is used in unsafe code blocks to work with raw memory. Operations on `loc<T>` include:
+This type is used in freedom code blocks to work with raw memory. Operations on `loc<T>` include:
 - Getting the address of a variable: `loc(x)`
 - Dereferencing a pointer: `at(p)`
 - Converting between pointer types: `from<loc<T>>(addr)`

--- a/doc/Intrinsics.md
+++ b/doc/Intrinsics.md
@@ -44,10 +44,10 @@ var<their<Foo>> b     = their<Foo>(owner)       // mutable borrow
 var<their<Foo const>> v = their<Foo const>(owner)  // immutable borrow
 ```
 
-Pointer declarations (inside `unsafe`):
+Pointer declarations (inside `freedom`):
 
 ```vyn
-unsafe {
+freedom {
   var<loc<Int>> p = loc(x)
   at(p) = 99
 }
@@ -141,13 +141,13 @@ fn view(owner)   -> their<T const>
 
 ---
 
-## 5. Memory Intrinsics (`unsafe` required)
+## 5. Memory Intrinsics (`freedom` required)
 
 ```vyn
-unsafe fn loc<T>(expr: T) -> loc<T>
-unsafe fn at<T>(pointer: loc<T>) -> T
-unsafe fn addr<T>(pointer: loc<T>) -> Int64
-unsafe fn from<P>(addr: Int64) -> P
+freedom fn loc<T>(expr: T) -> loc<T>
+freedom fn at<T>(pointer: loc<T>) -> T
+freedom fn addr<T>(pointer: loc<T>) -> Int64
+freedom fn from<P>(addr: Int64) -> P
 ```
 
 - **`loc<T>(expr)`**: address‑of a value → `loc<T>`.  
@@ -330,6 +330,6 @@ fn mem_set(ptr: loc<UInt8>, value: UInt8, n: UInt) -> Void
 1. **Declarations**: choose explicit (`var<T>`) or inferred (`var auto`).  
 2. **Functions**: return in `<Type>`, arrow mandatory, braces optional for single expressions.  
 3. **Ownership**: use `my<T>`, `our<T>`, `their<T>`, with optional `borrow()`/`view()` shorthand.  
-4. **Intrinsics**: memory ops only in `unsafe`, metadata always safe.  
+4. **Intrinsics**: memory ops only in `freedom`, metadata always safe.  
 5. **Serialization**: use auto-serialization for `main()` returns; mode intrinsics for customization.
 6. **Stability**: Sections 4–7 are stable; Section 8 is experimental.

--- a/doc/Memory_Operations.md
+++ b/doc/Memory_Operations.md
@@ -1,14 +1,14 @@
 # Vyn Memory Operations
 
-This document describes Vyn's memory model and the operations available for low-level memory manipulation. Vyn follows a hybrid approach to memory management, with safe memory operations by default and explicit unsafe operations when needed.
+This document describes Vyn's memory model and the operations available for low-level memory manipulation. Vyn follows a hybrid approach to memory management, with safe memory operations by default and explicit freedom operations when needed.
 
 ## 1. Memory Safety Philosophy
 
 Vyn's memory model is designed with these principles:
 
 - **Safe by Default**: Normal Vyn code operates with memory safety guarantees
-- **Explicit Unsafety**: Unsafe operations must be contained within `unsafe` blocks
-- **Minimal Unsafe Surface**: The language minimizes the number of unsafe operations needed
+- **Explicit Unsafety**: Freedom operations must be contained within `freedom` blocks
+- **Minimal Freedom Surface**: The language minimizes the number of freedom operations needed
 - **Clear Intent**: Memory operations use clear syntax that indicates their purpose
 
 ## 2. Pointer Types
@@ -19,14 +19,14 @@ The `loc<T>` type represents a raw pointer to memory containing a value of type 
 
 - **Syntax**: `loc<T>`
 - **AST Representation**: `GenericInstanceTypeNode` with a base type of "loc" and a type argument of `T`
-- **Safety**: Always considered unsafe to dereference or modify
+- **Safety**: Always considered freedom to dereference or modify
 
 Example:
 ```vyn
 var<Int> x = 42;
 var<loc<Int>> p; // Declares a pointer to Int
 
-unsafe {
+freedom {
     p = loc(x);  // Sets p to point to x
 }
 ```
@@ -49,12 +49,12 @@ The `loc()` operation creates a pointer to a variable.
 - **AST Representation**:
   - `ConstructionExpression` with type "loc" and the target expression as an argument
   - Or `CallExpression` with identifier "loc" and the target expression as an argument
-- **Safety**: Must be used within an `unsafe` block
+- **Safety**: Must be used within an `freedom` block
 
 Example:
 ```vyn
 var<Int> x = 42;
-unsafe {
+freedom {
     var<loc<Int>> p = loc(x);
 }
 ```
@@ -70,11 +70,11 @@ The `at()` operation accesses the value at a pointer's location.
 - **Behavior**:
   - When used on the right side of an assignment: Loads the value from the pointer
   - When used on the left side of an assignment: Sets up a store to the pointer
-- **Safety**: Must be used within an `unsafe` block
+- **Safety**: Must be used within an `freedom` block
 
 Examples:
 ```vyn
-unsafe {
+freedom {
     var<Int> y = at(p);  // Reading from a pointer (load)
     at(p) = 99;          // Writing to a pointer (store)
 }
@@ -87,11 +87,11 @@ The `from<loc<T>>()` operation converts between different pointer types or from 
 - **Syntax**: `from<loc<T>>(expr)`
 - **Return Type**: `loc<T>`
 - **AST Representation**: `ConstructionExpression` with a `GenericInstanceTypeNode` for "from" and the source expression as an argument
-- **Safety**: Must be used within an `unsafe` block
+- **Safety**: Must be used within an `freedom` block
 
 Examples:
 ```vyn
-unsafe {
+freedom {
      // Convert an integer to a pointer
     var<Int> addr = 0x12345678;
     var<loc<Int>> p = from<loc<Int>>(addr);
@@ -102,12 +102,12 @@ unsafe {
 }
 ```
 
-## 4. Unsafe Blocks
+## 4. Freedom Blocks
 
-All memory operations must be contained within `unsafe` blocks, which are represented as `UnsafeBlockStatement` nodes in the AST.
+All memory operations must be contained within `freedom` blocks, which are represented as `UnsafeBlockStatement` nodes in the AST.
 
-- **Syntax**: `unsafe { ... }`
-- **AST Representation**: `UnsafeBlockStatement` containing a `BlockStatement` with the unsafe operations
+- **Syntax**: `freedom { ... }`
+- **AST Representation**: `UnsafeBlockStatement` containing a `BlockStatement` with the freedom operations
 - **Purpose**: Explicitly marks code that may violate memory safety
 
 Example:
@@ -115,14 +115,14 @@ Example:
 var<Int> x = 42;
 var<loc<Int>> p;
 
-unsafe {
+freedom {
     p = loc(x);
     at(p) = 99;
 }
 
 // The following would cause a compile-time error:
-// p = loc(x);  // Error: 'loc' operation outside unsafe block
-// at(p) = 99;  // Error: 'at' operation outside unsafe block
+// p = loc(x);  // Error: 'loc' operation outside freedom block
+// at(p) = 99;  // Error: 'at' operation outside freedom block
 ```
 
 ## 5. Error Cases and Safety Checks
@@ -130,7 +130,7 @@ unsafe {
 The Vyn compiler and runtime perform various safety checks:
 
 1. **Compile-time checks**:
-   - Memory operations outside unsafe blocks are rejected
+   - Memory operations outside freedom blocks are rejected
    - Type mismatches in pointer operations are caught
    - Null pointer constants are detected
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -146,10 +146,10 @@ As the Vyn project grows, a more structured directory layout will be beneficial 
 -   **Memory Layout**: Define and document memory layout guarantees for all types, ensuring consistent behavior across platforms.
 -   **FFI Compatibility**: Ensure all primitive types have well-defined mappings to C/C++ equivalents for FFI interoperability.
 
-### Refinement of Memory Model and Unsafe Operations
+### Refinement of Memory Model and Freedom Operations
 
 -   **Complete LLVM Codegen**: Finish the implementation and refinement of LLVM code generation for `LocationExpression`, `PointerDerefExpression`, `AddrOfExpression`, and `FromIntToLocExpression` in `src/vre/llvm/cgen_expr.cpp`.
--   **Enhance Semantic Analysis**: Strengthen semantic checks related to memory operations, including more robust type validation and analysis within `unsafe` blocks.
+-   **Enhance Semantic Analysis**: Strengthen semantic checks related to memory operations, including more robust type validation and analysis within `freedom` blocks.
 -   **Runtime Checks (Optional)**: Investigate adding optional runtime checks for null pointer dereferences and out-of-bounds access, potentially controlled by build flags.
 
 ### Formalization of Compiler Intrinsics
@@ -436,7 +436,7 @@ This feature will enable scripts and API-style binaries to return structured dat
     ```
 -   **Casting Operations**: Formalize and implement casting operations, including:
     -   `cast<T>(expr)`: Explicit casting of expression to type T
-    -   Safe versus unsafe casts, with appropriate compiler warnings or errors
+    -   Safe versus freedom casts, with appropriate compiler warnings or errors
     -   Rules for implicit conversions between compatible types
 
 ### Polymorphism and Type System

--- a/doc/RUNTIME.md
+++ b/doc/RUNTIME.md
@@ -52,7 +52,7 @@ Vyn employs ownership types to manage memory and control data access:
 *   **`my<T>`**: Unique-owning pointer (similar to Rust's `Box<T>`). Only one `my<T>` can own the data. When a `my<T>` goes out of scope, the data is deallocated.
 *   **`our<T>`**: Shared-owning pointer (reference-counted, like `Rc<T>`/`Arc<T>`). Multiple `our<T>` pointers can co-own the data. The data is deallocated when the last `our<T>` is dropped.
 *   **`their<T>`**: Borrowed pointer (non-owning reference, like `&T`/`&mut T`). It provides temporary access to data owned by `my<T>` or `our<T>`, or other `their<T>`.
-*   **`ptr<T>`**: Raw pointer (like `T*`). Operations involving `ptr<T>` are typically restricted to `unsafe` blocks.
+*   **`ptr<T>`**: Raw pointer (like `T*`). Operations involving `ptr<T>` are typically restricted to `freedom` blocks.
 
 **Data Mutability** is controlled by applying `const` to the type `T` *within* the ownership wrapper:
 *   `my<T>`: Unique ownership of mutable data `T`.

--- a/doc/TODO_CURRENT.md
+++ b/doc/TODO_CURRENT.md
@@ -19,7 +19,7 @@
 - ✅ **Auto-Serialization**: Complex return types output JSON automatically
 - ✅ **Type Safety**: Strong type checking with clear error messages
 - ✅ **Memory Management**: Ownership types (my<T>, our<T>, their<T>)
-- ✅ **Unsafe Operations**: loc<T> pointers with proper unsafe blocks
+- ✅ **Freedom Operations**: loc<T> pointers with proper freedom blocks
 - ✅ **Source Locations**: Comprehensive error reporting with file/line info
 - ✅ **Parser Robustness**: Handles complex syntax including templates, async
 - ✅ **Git Workflow**: Regular commits, proper branching (v0.3.7)

--- a/doc/VRE.md
+++ b/doc/VRE.md
@@ -23,7 +23,7 @@ Vyn aims for memory safety without a traditional garbage collector by default.
     *   `Box<T>`: For heap-allocated data with a single owner.
     *   References (`&T`, `&mut T`): For borrowed data.
 *   **Automatic Reference Counting (ARC):** For shared ownership scenarios (`Shared<T>` or similar), ARC might be implemented. This would involve runtime overhead for reference count updates.
-*   **Manual Management:** Unsafe blocks might allow for manual memory management, but this should be rare.
+*   **Manual Management:** Freedom blocks might allow for manual memory management, but this should be rare.
 *   **Stack Allocation:** Value types (structs, enums, primitives) will primarily be stack-allocated where possible.
 
 ## 4. Type System and Data Representation

--- a/doc/Vyn_Guide_Outline.md
+++ b/doc/Vyn_Guide_Outline.md
@@ -45,7 +45,7 @@
 8. **Ownership & Memory Model**
    8.1. `my<T>`, `our<T>`, `their<T>` Semantics  
    8.2. Borrow-Checker Rules  
-   8.3. `unsafe {}` and Raw Pointers (`loc`, `at`, `addr`, `from`)  
+   8.3. `freedom {}` and Raw Pointers (`loc`, `at`, `addr`, `from`)  
    8.4. Intrinsics Reference  
 
 9. **Concurrency Primitives**

--- a/doc/mem_RFC.md
+++ b/doc/mem_RFC.md
@@ -10,9 +10,9 @@ Vyn’s memory model combines two primary axes for safe bindings plus a third fo
 
 1. **Binding Mutability** (`var` vs `const`)
 2. **Ownership & Data Mutability** (`my<T>` / `our<T>` / `their<T>` with optional `T const`)
-3. **Raw Locations** (`loc<T>`, gated by `unsafe { … }`)
+3. **Raw Locations** (`loc<T>`, gated by `freedom { … }`)
 
-Safe code uses only `my`/`our`/`their`; raw locations (`loc<T>`) live behind explicit `unsafe { … }` blocks.
+Safe code uses only `my`/`our`/`their`; raw locations (`loc<T>`) live behind explicit `freedom { … }` blocks.
 
 ---
 
@@ -39,7 +39,7 @@ const<Int> limit = 100  // immutable binding
 * **`my<T>`**: unique-own pointer (like Rust’s `Box<T>`)
 * **`our<T>`**: shared-own pointer (ref-counted, like `Rc<T>`/`Arc<T>`)
 * **`their<T>`**: borrowed pointer (non-owning reference, like `&T`/`&mut T`)
-* **`loc<T>`**: raw location (`T*`), operations gated by `unsafe { … }`
+* **`loc<T>`**: raw location (`T*`), operations gated by `freedom { … }`
 
 Data mutability is controlled by `const` on the pointee: e.g., `my<Foo const>` means unique-own pointer to immutable data.
 
@@ -149,15 +149,15 @@ Vyn’s `Mutex<T>` does not automatically detect deadlocks (e.g., lock cycles). 
 
 ### 7.5 Summary
 
-The `LockGuard<T>` scope defines the "baton" of lock ownership. Timeouts via `lock_timeout` prevent indefinite blocking. Poisoning signals an unsafe state after a panic during a critical section. Deadlock is a developer responsibility, mitigated by strategies like lock ordering, timeouts, or restructuring lock acquisitions. This design aims to balance simplicity (e.g., `lock()`) with safety features (timeouts, poisoning) and clear semantics for concurrent access.
+The `LockGuard<T>` scope defines the "baton" of lock ownership. Timeouts via `lock_timeout` prevent indefinite blocking. Poisoning signals an freedom state after a panic during a critical section. Deadlock is a developer responsibility, mitigated by strategies like lock ordering, timeouts, or restructuring lock acquisitions. This design aims to balance simplicity (e.g., `lock()`) with safety features (timeouts, poisoning) and clear semantics for concurrent access.
 
 ---
 
-## 8. Unsafe-Scoped Blocks
+## 8. Freedom-Scoped Blocks
 
 ```vyn
 fn use_raw()
-  unsafe {
+  freedom {
     var l: loc<Foo> = alloc(sizeof(Foo))
     (*l).field = 42
     free(l)
@@ -165,7 +165,7 @@ fn use_raw()
 // Outside, `l` can be moved or stored safely
 ```
 
-**Comment:** Scoped `unsafe { … }` blocks localize undefined behavior risks.
+**Comment:** Scoped `freedom { … }` blocks localize undefined behavior risks.
 
 ---
 
@@ -185,10 +185,10 @@ fn use_raw()
 | `const<their<Foo>> p`       | immutable | borrowed  | mutable         | ✔️           |
 | `var<their<Foo const>> p`   | mutable   | borrowed  | immutable       | ✔️           |
 | `const<their<Foo const>> p` | immutable | borrowed  | immutable       | ✔️           |
-| `var<loc<Foo>> l`           | mutable   | raw       | mutable         | ❌ (`unsafe`) |
-| `const<loc<Foo>> l`         | immutable | raw       | mutable         | ❌ (`unsafe`) |
-| `var<loc<Foo const>> l`     | mutable   | raw       | immutable       | ❌ (`unsafe`) |
-| `const<loc<Foo const>> l`   | immutable | raw       | immutable       | ❌ (`unsafe`) |
+| `var<loc<Foo>> l`           | mutable   | raw       | mutable         | ❌ (`freedom`) |
+| `const<loc<Foo>> l`         | immutable | raw       | mutable         | ❌ (`freedom`) |
+| `var<loc<Foo const>> l`     | mutable   | raw       | immutable       | ❌ (`freedom`) |
+| `const<loc<Foo const>> l`   | immutable | raw       | immutable       | ❌ (`freedom`) |
 
 ---
 
@@ -231,13 +231,13 @@ var v3: their<Baz const> = view v1     // creating an immutable view from an imm
 
 ```vyn
 fn alloc_foo() -> loc<Foo>
-  unsafe {
+  freedom {
     return alloc(sizeof(Foo))
   }
 
 fn main()
   var l: loc<Foo> = alloc_foo()
-  unsafe {
+  freedom {
     (*l).x = 123
     free(l)
   }

--- a/examples/memory_semantics.vyn
+++ b/examples/memory_semantics.vyn
@@ -4,7 +4,7 @@
 main()<Int> -> {
     x<Int> = 42;
     
-    unsafe {
+    freedom {
         p<loc<Int>> = loc(x);
         at(p) = 42;
         // Test the new view and borrow operators

--- a/examples/quicksort.vyn
+++ b/examples/quicksort.vyn
@@ -125,7 +125,7 @@ fn<Void> swap(array<their<[T]>>, i<Int>, j<Int>) -> {
 
 // ----- Memory-Optimized Version -----
 
-// Higher performance version using unsafe operations for specific scenarios
+// Higher performance version using freedom operations for specific scenarios
 // where maximum performance is required
 fn<Void> quicksort_unsafe(array<their<[T]>>) -> {
     quicksort_range_unsafe(array, 0, array.len() - 1);
@@ -143,7 +143,7 @@ fn<Int> partition_unsafe(array<their<[T]>>, low<Int>, high<Int>) -> {
     const<T> pivot = array[high];
     i<Int> = low - 1;
     
-    unsafe {
+    freedom {
         // Use direct memory access for very large arrays as an optimization
         arr_ptr<loc<[T]>> = loc(array);
         
@@ -163,7 +163,7 @@ fn<Int> partition_unsafe(array<their<[T]>>, low<Int>, high<Int>) -> {
 fn<Void> swap_unsafe(array_ptr<loc<[T]>>, i<Int>, j<Int>) -> {
     if i == j { return; }
     
-    unsafe {
+    freedom {
         // Direct pointer arithmetic for maximum performance
         const<Int> elem_size = sizeof<T>();
         base_ptr<loc<T>> = from<loc<T>>(addr(array_ptr));

--- a/include/vyn/parser/ast.hpp
+++ b/include/vyn/parser/ast.hpp
@@ -120,7 +120,7 @@ enum class OwnershipKind {
     MY,    // Unique ownership
     OUR,   // Shared ownership (e.g., reference counted)
     THEIR, // Borrowed/Viewed (non-owning), further specified by BorrowKind if applicable
-    PTR    // Raw pointer (potentially non-owning, unsafe)
+    PTR    // Raw pointer (potentially non-owning, freedom)
     // Add other kinds as needed
 };
 

--- a/include/vyn/parser/token.hpp
+++ b/include/vyn/parser/token.hpp
@@ -28,7 +28,7 @@ enum class TokenType {
     KEYWORD_MY, KEYWORD_OUR, KEYWORD_THEIR, KEYWORD_PTR, // New ownership keywords
     KEYWORD_BORROW, KEYWORD_VIEW, // Changed from BORROW_MUT
     KEYWORD_NIL, // Added for nil literal
-    KEYWORD_UNSAFE, // Added for unsafe blocks
+    KEYWORD_FREEDOM, // Added for freedom blocks
     KEYWORD_AUTO, // Added for auto type inference
 
     // Operators

--- a/include/vyn/vyn.hpp
+++ b/include/vyn/vyn.hpp
@@ -16,7 +16,7 @@
  * ✅ Select expressions with pass keyword (expression-based pattern matching)
  * ✅ Comparison patterns (>=, <=, <, >, ==, !=) with unreachable pattern detection
  * ✅ Type system with ownership (my<T>, our<T>, their<T>)
- * ✅ Memory safety with borrowing (view, borrow) and unsafe blocks
+ * ✅ Memory safety with borrowing (view, borrow) and freedom blocks
  * ✅ Comprehensive parser supporting templates, async, classes
  * 📋 Standard library modules (planned)
  * 

--- a/src/parser/ast.cpp
+++ b/src/parser/ast.cpp
@@ -819,7 +819,7 @@ void IfExpression::accept(Visitor& visitor) {
 // Member in hpp: block
 // toString() is already declared in hpp.
 std::string UnsafeStatement::toString() const {
-    return "unsafe " + (block ? block->toString() : "{}");
+    return "freedom " + (block ? block->toString() : "{}");
 }
 
 // --- TypeName ---

--- a/src/parser/lexer.cpp
+++ b/src/parser/lexer.cpp
@@ -478,7 +478,7 @@ vyn::TokenType Lexer::get_keyword_type(const std::string& word) {
         {"my", vyn::TokenType::KEYWORD_MY},
         {"our", vyn::TokenType::KEYWORD_OUR},
         {"their", vyn::TokenType::KEYWORD_THEIR},
-        {"unsafe", vyn::TokenType::KEYWORD_UNSAFE},
+        {"freedom", vyn::TokenType::KEYWORD_FREEDOM},
         {"ptr", vyn::TokenType::KEYWORD_PTR},
         {"borrow", vyn::TokenType::KEYWORD_BORROW},
         {"view", vyn::TokenType::KEYWORD_VIEW},

--- a/src/parser/statement_parser.cpp
+++ b/src/parser/statement_parser.cpp
@@ -79,7 +79,7 @@ vyn::ast::StmtPtr StatementParser::parse() {
             return parse_block();
         case vyn::TokenType::KEYWORD_TRY:
             return parse_try();
-        case vyn::TokenType::KEYWORD_UNSAFE:
+        case vyn::TokenType::KEYWORD_FREEDOM:
             return parse_unsafe();
         case vyn::TokenType::KEYWORD_DEFER:
             return parse_defer();
@@ -838,7 +838,7 @@ bool StatementParser::is_statement_start(vyn::TokenType type) const {
         case vyn::TokenType::LBRACE:
         case vyn::TokenType::KEYWORD_BREAK:
         case vyn::TokenType::KEYWORD_CONTINUE:
-        case vyn::TokenType::KEYWORD_UNSAFE:
+        case vyn::TokenType::KEYWORD_FREEDOM:
         case vyn::TokenType::IDENTIFIER: // Added identifier for relaxed syntax
             return true;
         default:
@@ -1120,9 +1120,9 @@ std::unique_ptr<vyn::ast::ContinueStatement> StatementParser::parse_continue() {
     return std::make_unique<vyn::ast::ContinueStatement>(continue_loc);
 }
 
-// Parses an unsafe block: 'unsafe { ... }'
+// Parses an freedom block: 'freedom { ... }'
 std::unique_ptr<vyn::ast::UnsafeStatement> StatementParser::parse_unsafe() {
-    SourceLocation loc = expect(vyn::TokenType::KEYWORD_UNSAFE, "Expected 'unsafe'").location;
+    SourceLocation loc = expect(vyn::TokenType::KEYWORD_FREEDOM, "Expected 'freedom'").location;
     auto blockStmt = parse_block(); // parse_block consumes '{' and '}'
     return std::make_unique<vyn::ast::UnsafeStatement>(loc, std::move(blockStmt));
 }

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -177,12 +177,12 @@ TEST_CASE("Print parser version", "[parser]") {
     REQUIRE(true); // Placeholder to ensure test runs
 }
 
-TEST_CASE("Semantic: from(addr) only allowed in unsafe", "[semantic][pointer][unsafe][test38]") {
+TEST_CASE("Semantic: from(addr) only allowed in freedom", "[semantic][pointer][freedom][test38]") {
     std::string source_ok = R"(
 fn<Int> main() -> {
     addr<Int> = 0x1234;
     p<loc<Int>>;
-    unsafe {
+    freedom {
         p = from<loc<Int>>(addr);
     }
     return 0;

--- a/src/vre/intrinsics.cpp
+++ b/src/vre/intrinsics.cpp
@@ -21,7 +21,7 @@ namespace intrinsics {
  *
  * MEMORY OPERATION IMPLEMENTATION LOCATIONS:
  * - AST Nodes: include/vyn/parser/ast.hpp (LocationExpression, PointerDerefExpression, etc.)
- * - Semantic Analysis: src/vre/semantic.cpp (type checking & unsafe block verification)
+ * - Semantic Analysis: src/vre/semantic.cpp (type checking & freedom block verification)
  * - Code Generation: src/vre/llvm/cgen_expr.cpp (LLVM IR generation)
  */
 

--- a/src/vre/llvm/cgen_stmt.cpp
+++ b/src/vre/llvm/cgen_stmt.cpp
@@ -596,13 +596,13 @@ void LLVMCodegen::visit(vyn::ast::TryStatement* node) {
 }
 
 void LLVMCodegen::visit(vyn::ast::UnsafeStatement* node) {
-    // For LLVM codegen, an unsafe block doesn't typically translate to specific LLVM instructions.
+    // For LLVM codegen, an freedom block doesn't typically translate to specific LLVM instructions.
     // Its purpose is to bypass semantic checks in the Vyn language itself.
     // So, we just visit the inner block.
     if (node->block) {
         node->block->accept(*this);
     }
-    // An unsafe statement, like a regular block, doesn't produce a value for further expressions.
+    // An freedom statement, like a regular block, doesn't produce a value for further expressions.
     m_currentLLVMValue = nullptr;
 }
 

--- a/src/vre/llvm/cgen_util.cpp
+++ b/src/vre/llvm/cgen_util.cpp
@@ -77,7 +77,7 @@ llvm::Value* LLVMCodegen::tryCast(llvm::Value* value, llvm::Type* targetType, co
     if (!value || !targetType) return nullptr;
     if (value->getType() == targetType) return value;
 
-    // Example: Integer to Pointer (potentially unsafe, use with care)
+    // Example: Integer to Pointer (potentially freedom, use with care)
     if (targetType->isPointerTy() && value->getType()->isIntegerTy()) {
         return builder->CreateIntToPtr(value, targetType, "inttoptr_cast");
     }

--- a/src/vre/semantic.cpp
+++ b/src/vre/semantic.cpp
@@ -51,7 +51,7 @@ SemanticAnalyzer::SemanticAnalyzer(Driver& driver) : driver_(driver), currentSco
         "let", "var", "const", "fn", "struct", "enum", "trait", "impl", "type", "class",
         "if", "else", "while", "for", "return", "break", "continue", "loop", "match",
         "try", "catch", "finally", "defer", "throw", "async", "await", "my", "our", "their",
-        "ptr", "borrow", "view", "unsafe", "pub", "template", "operator", "as", "in", "ref",
+        "ptr", "borrow", "view", "freedom", "pub", "template", "operator", "as", "in", "ref",
         "extern", "import", "smuggle", "module", "use", "mut", "scoped", "bundle",
         "true", "false", "null", "nil",
         "addr", "at", "loc", "from",
@@ -629,9 +629,9 @@ void SemanticAnalyzer::visit(ast::CallExpression* node) {
         
         // Handle borrow()/view() intrinsics
         if (name == "borrow" || name == "view") {
-            // Must be used within unsafe block
+            // Must be used within freedom block
             if (!isInUnsafeBlock()) {
-                addError(name + "() can only be used inside an unsafe block", node);
+                addError(name + "() can only be used inside an freedom block", node);
             }
             if (node->arguments.size() != 1) {
                 addError(name + "() expects exactly one argument", node);
@@ -1966,9 +1966,9 @@ void SemanticAnalyzer::visit(ast::GenericInstantiationExpression* node) {
     }
 }
 void SemanticAnalyzer::visit(ast::PointerDerefExpression* node) {
-    // at() intrinsic only allowed inside an unsafe block
+    // at() intrinsic only allowed inside an freedom block
     if (!isInUnsafeBlock()) {
-        addError("at() (pointer dereference) is only allowed inside an unsafe block.", node);
+        addError("at() (pointer dereference) is only allowed inside an freedom block.", node);
         expressionTypes[node] = nullptr;
         return;
     }
@@ -2020,9 +2020,9 @@ void SemanticAnalyzer::visit(ast::PointerDerefExpression* node) {
     node->type = std::shared_ptr<ast::TypeNode>(pointeeType->clone()); // node->type takes ownership of a new clone
 }
 void SemanticAnalyzer::visit(ast::AddrOfExpression* node) {
-    // addr() intrinsic only allowed inside an unsafe block
+    // addr() intrinsic only allowed inside an freedom block
     if (!isInUnsafeBlock()) {
-        addError("addr() is only allowed inside an unsafe block.", node);
+        addError("addr() is only allowed inside an freedom block.", node);
         expressionTypes[node] = nullptr;
         return;
     }
@@ -2055,9 +2055,9 @@ void SemanticAnalyzer::visit(ast::AddrOfExpression* node) {
     node->type = std::shared_ptr<ast::TypeNode>(addrAstType->clone());
 }
 void SemanticAnalyzer::visit(ast::FromIntToLocExpression* node) {
-    // from<T>() intrinsic only allowed inside an unsafe block
+    // from<T>() intrinsic only allowed inside an freedom block
     if (!isInUnsafeBlock()) {
-        addError("from<Type>(expr) is only allowed inside an unsafe block.", node);
+        addError("from<Type>(expr) is only allowed inside an freedom block.", node);
         expressionTypes[node] = nullptr;
         return;
     }
@@ -2110,9 +2110,9 @@ void SemanticAnalyzer::visit(ast::FromIntToLocExpression* node) {
     node->type = std::shared_ptr<ast::TypeNode>(targetType->clone());
 }
 void SemanticAnalyzer::visit(ast::LocationExpression* node) {
-    // Check if we're in an unsafe block
+    // Check if we're in an freedom block
     if (!isInUnsafeBlock()) {
-        addError("loc() (location-of) is only allowed inside an unsafe block.", node);
+        addError("loc() (location-of) is only allowed inside an freedom block.", node);
         expressionTypes[node] = nullptr;
         return;
     }
@@ -2241,7 +2241,7 @@ void SemanticAnalyzer::visit(ast::TryStatement* node) {
     }
 }
 void SemanticAnalyzer::visit(ast::UnsafeStatement* node) {
-    // Enter a new scope for the unsafe block
+    // Enter a new scope for the freedom block
     enterScope();
     currentScope->isUnsafeBlock = true;
     node->block->accept(*this);

--- a/test/debug/debug_parser_corrected.vyn
+++ b/test/debug/debug_parser_corrected.vyn
@@ -1,7 +1,7 @@
 main()<Int> -> {
     addr<Int> = 0x1234;
     p<loc<Int>>;
-    unsafe {
+    freedom {
         p = from<loc<Int>>(addr);
     }
     return 0;

--- a/test/debug/debug_pointer.vyn
+++ b/test/debug/debug_pointer.vyn
@@ -3,7 +3,7 @@ main()<Int> -> {
     x<Int> = 42;
     print("Initial x:", x);
     
-    unsafe {
+    freedom {
         p<loc<Int>> = loc(x);
         print("Before at(p) assignment, x:", x);
         at(p) = 100;

--- a/test/debug/debug_unsafe.vyn
+++ b/test/debug/debug_unsafe.vyn
@@ -1,1 +1,1 @@
-unsafe { x<Int> = 5; }
+freedom { x<Int> = 5; }

--- a/test/debug/debug_unsafe_in_fn.vyn
+++ b/test/debug/debug_unsafe_in_fn.vyn
@@ -1,1 +1,1 @@
-main()<Int> -> { unsafe { x<Int> = 5; } return 42; }
+main()<Int> -> { freedom { x<Int> = 5; } return 42; }

--- a/test/debug/debug_unsafe_simple.vyn
+++ b/test/debug/debug_unsafe_simple.vyn
@@ -1,1 +1,1 @@
-main()<String> -> { return "unsafe test"; }
+main()<String> -> { return "freedom test"; }

--- a/test/memory/README.md
+++ b/test/memory/README.md
@@ -80,7 +80,7 @@ build/vyn test/memory/borrow_test.vyn
 - Pointer dereferencing with `at()`
 - Creating borrows with `borrow()`
 - Creating views with `view()`
-- All inside `unsafe {}` blocks
+- All inside `freedom {}` blocks
 
 **Expected behavior**:
 - Returns 100 (modified value through pointer)
@@ -110,15 +110,15 @@ build/vyn test/memory/simple_memory_test.vyn
 |-----------|--------|---------|-------------|
 | Unique constructor | `my(expr)` | `my<T>` | Creates unique ownership |
 | Shared constructor | `our(expr)` | `our<T>` | Creates shared ownership |
-| Mutable borrow | `borrow(expr)` | `their<T>` | Borrows mutably (unsafe) |
-| Immutable borrow | `view(expr)` | `their<T const>` | Borrows immutably (unsafe) |
-| Pointer creation | `loc(expr)` | `loc<T>` | Gets memory location (unsafe) |
-| Pointer dereference | `at(ptr)` | `T` | Accesses value at pointer (unsafe) |
+| Mutable borrow | `borrow(expr)` | `their<T>` | Borrows mutably (freedom) |
+| Immutable borrow | `view(expr)` | `their<T const>` | Borrows immutably (freedom) |
+| Pointer creation | `loc(expr)` | `loc<T>` | Gets memory location (freedom) |
+| Pointer dereference | `at(ptr)` | `T` | Accesses value at pointer (freedom) |
 
 ### Safety Rules
 
-1. **`borrow()` and `view()` require `unsafe {}`** - These operations bypass ownership checks
-2. **`loc()` and `at()` require `unsafe {}`** - Direct memory access is inherently unsafe
+1. **`borrow()` and `view()` require `freedom {}`** - These operations bypass ownership checks
+2. **`loc()` and `at()` require `freedom {}`** - Direct memory access is inherently freedom
 3. **`my<T>` ownership is unique** - Only one owner at a time (moves invalidate original)
 4. **`our<T>` is reference counted** - Multiple owners share immutable data
 5. **`their<T>` is temporary** - Borrows must not outlive their owner
@@ -147,10 +147,10 @@ All tests should:
 
 ## Common Issues
 
-### "borrow() can only be used inside an unsafe block"
-**Solution**: Wrap `borrow()` and `view()` calls in `unsafe {}` blocks:
+### "borrow() can only be used inside an freedom block"
+**Solution**: Wrap `borrow()` and `view()` calls in `freedom {}` blocks:
 ```vyn
-unsafe {
+freedom {
     borrowed<their<Int>> = borrow(data)
 }
 ```
@@ -159,15 +159,15 @@ unsafe {
 **Solution**: Ensure you're borrowing from `my<T>` or `our<T>`, not plain `T`:
 ```vyn
 data<my<Int>> = my(42)  // Correct
-unsafe {
+freedom {
     borrowed<their<Int>> = borrow(data)  // Works
 }
 ```
 
 ### Pointer operations fail
-**Solution**: All pointer operations require `unsafe {}`:
+**Solution**: All pointer operations require `freedom {}`:
 ```vyn
-unsafe {
+freedom {
     ptr<loc<Int>> = loc(x)
     value<Int> = at(ptr)
 }

--- a/test/memory/ownership_simple_test.vyn
+++ b/test/memory/ownership_simple_test.vyn
@@ -6,7 +6,7 @@ main()<Int> -> {
     x<my<Int>> = my(42)
     println("Test 1: Created my<Int> = 42")
     
-    unsafe {
+    freedom {
         b<their<Int>> = borrow(x)
         b = 99
         println("Test 2: Borrowed and modified to 99")
@@ -15,7 +15,7 @@ main()<Int> -> {
     println("Value after borrow: " + x.to_string())
     
     // Test 3: view (read-only)
-    unsafe {
+    freedom {
         v<their<Int const>> = view(x)
         println("Test 3: Viewed value through view")
     }

--- a/test/memory/ownership_test.vyn
+++ b/test/memory/ownership_test.vyn
@@ -37,7 +37,7 @@ test_borrow_mutable()<Int> -> {
     data<my<TestData>> = my(TestData { value = 100, name = "test" })
     println("Created TestData with value: 100")
     
-    unsafe {
+    freedom {
         borrowed<their<TestData>> = borrow(data)
         println("Created mutable borrow")
         
@@ -56,7 +56,7 @@ test_view_immutable()<Int> -> {
     data<my<Int>> = my(42)
     println("Created my<Int> with value: 42")
     
-    unsafe {
+    freedom {
         viewed<their<Int const>> = view(data)
         println("Created immutable view")
         
@@ -76,7 +76,7 @@ test_loc_at_pointers()<Int> -> {
     x<Int> = 42
     println("Created Int x = 42")
     
-    unsafe {
+    freedom {
         ptr<loc<Int>> = loc(x)
         println("Created pointer to x")
         
@@ -102,7 +102,7 @@ test_borrow_function_params()<Int> -> {
     data<my<TestData>> = my(TestData { value = 10, name = "param_test" })
     println("Created TestData with value: 10")
     
-    unsafe {
+    freedom {
         modify_through_borrow(borrow(data))
     }
     
@@ -121,7 +121,7 @@ test_view_function_params()<Int> -> {
     data<my<TestData>> = my(TestData { value = 99, name = "view_test" })
     println("Created TestData with value: 99")
     
-    unsafe {
+    freedom {
         result<Int> = read_through_view(view(data))
         println("Read value through view function: " + result.to_string())
     }
@@ -144,7 +144,7 @@ test_ownership_chain()<Int> -> {
     
     result<Int> = 0
     
-    unsafe {
+    freedom {
         // Borrow the unique
         borrowed_unique<their<Int>> = borrow(unique)
         borrowed_unique = 10
@@ -168,7 +168,7 @@ test_string_ownership()<Int> -> {
     text<my<String>> = my("Hello, Vyn!")
     println("Created my<String>: Hello, Vyn!")
     
-    unsafe {
+    freedom {
         viewed<their<String const>> = view(text)
         length<Int> = viewed.len()
         println("String length through view: " + length.to_string())
@@ -183,7 +183,7 @@ test_sequential_borrows()<Int> -> {
     data<my<Int>> = my(5)
     println("Created my<Int> = 5")
     
-    unsafe {
+    freedom {
         // First borrow
         borrow1<their<Int>> = borrow(data)
         borrow1 = borrow1 * 2

--- a/test/memory/simple_memory_test.vyn
+++ b/test/memory/simple_memory_test.vyn
@@ -2,7 +2,7 @@
 main()<Int> -> {
     x<Int> = 42;
     
-    unsafe {
+    freedom {
         p<loc<Int>> = loc(x);
         at(p) = 100;  // Change x through pointer
         b<their<Int>> = borrow(x);

--- a/test/memory/syntax_test.vyn
+++ b/test/memory/syntax_test.vyn
@@ -6,7 +6,7 @@ main()<Int> -> {
     println("Created x = 42")
     
     // Test that borrow() and view() parse correctly with function-call syntax
-    unsafe {
+    freedom {
         p<loc<Int>> = loc(x)
         at(p) = 100
         println("Modified x through pointer to 100")

--- a/test/memory/test_summary.txt
+++ b/test/memory/test_summary.txt
@@ -46,7 +46,7 @@ TEST COVERAGE:
 ✓ Complex ownership chains
 ✓ Sequential borrow operations
 ✓ String ownership
-✓ Unsafe block requirements
+✓ Freedom block requirements
 
 VERIFICATION:
 ============

--- a/test/units/extracted/test38.vyn
+++ b/test/units/extracted/test38.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test38.vyn
-// @test: Semantic: from(addr) only allowed in unsafe
-// @description: Extracted from tests.cpp - Semantic: from(addr) only allowed in unsafe
+// @test: Semantic: from(addr) only allowed in freedom
+// @description: Extracted from tests.cpp - Semantic: from(addr) only allowed in freedom
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/extracted/test39.vyn
+++ b/test/units/extracted/test39.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test39.vyn
-// @test: Codegen: addr(loc) and from(addr) round-trip in unsafe
-// @description: Extracted from tests.cpp - Codegen: addr(loc) and from(addr) round-trip in unsafe
+// @test: Codegen: addr(loc) and from(addr) round-trip in freedom
+// @description: Extracted from tests.cpp - Codegen: addr(loc) and from(addr) round-trip in freedom
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/extracted/test40.vyn
+++ b/test/units/extracted/test40.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test40.vyn
-// @test: Parser: Basic unsafe block
-// @description: Extracted from tests.cpp - Parser: Basic unsafe block
+// @test: Parser: Basic freedom block
+// @description: Extracted from tests.cpp - Parser: Basic freedom block
 // @category: parser
 // @expect: pass
 // @parse-only: true
@@ -10,5 +10,5 @@
 
     std::string source = R"(
 fn main() -> Int{
-    unsafe {
+    freedom {
         x<Int> = 1;

--- a/test/units/extracted/test41.vyn
+++ b/test/units/extracted/test41.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test41.vyn
-// @test: Semantic: 'loc(var)' requires unsafe block
-// @description: Extracted from tests.cpp - Semantic: 'loc(var)' requires unsafe block
+// @test: Semantic: 'loc(var)' requires freedom block
+// @description: Extracted from tests.cpp - Semantic: 'loc(var)' requires freedom block
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/extracted/test42.vyn
+++ b/test/units/extracted/test42.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test42.vyn
-// @test: Semantic: 'at(loc_var)' (read) requires unsafe block
-// @description: Extracted from tests.cpp - Semantic: 'at(loc_var)' (read) requires unsafe block
+// @test: Semantic: 'at(loc_var)' (read) requires freedom block
+// @description: Extracted from tests.cpp - Semantic: 'at(loc_var)' (read) requires freedom block
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/extracted/test43.vyn
+++ b/test/units/extracted/test43.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test43.vyn
-// @test: Semantic: 'at(loc_var) = val' (write) requires unsafe block
-// @description: Extracted from tests.cpp - Semantic: 'at(loc_var) = val' (write) requires unsafe block
+// @test: Semantic: 'at(loc_var) = val' (write) requires freedom block
+// @description: Extracted from tests.cpp - Semantic: 'at(loc_var) = val' (write) requires freedom block
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/extracted/test44.vyn
+++ b/test/units/extracted/test44.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test44.vyn
-// @test: Semantic: 'from(addr_val)' requires unsafe block (already covered but good to be explicit)
-// @description: Extracted from tests.cpp - Semantic: 'from(addr_val)' requires unsafe block (already covered but good to be explicit)
+// @test: Semantic: 'from(addr_val)' requires freedom block (already covered but good to be explicit)
+// @description: Extracted from tests.cpp - Semantic: 'from(addr_val)' requires freedom block (already covered but good to be explicit)
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/extracted/test45.vyn
+++ b/test/units/extracted/test45.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test45.vyn
-// @test: Semantic: 'addr(loc_var)' is safe (does not require unsafe block)
-// @description: Extracted from tests.cpp - Semantic: 'addr(loc_var)' is safe (does not require unsafe block)
+// @test: Semantic: 'addr(loc_var)' is safe (does not require freedom block)
+// @description: Extracted from tests.cpp - Semantic: 'addr(loc_var)' is safe (does not require freedom block)
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/extracted/test51.vyn
+++ b/test/units/extracted/test51.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test51.vyn
-// @test: Codegen: 'loc()' and 'at()' for write in unsafe block
-// @description: Extracted from tests.cpp - Codegen: 'loc()' and 'at()' for write in unsafe block
+// @test: Codegen: 'loc()' and 'at()' for write in freedom block
+// @description: Extracted from tests.cpp - Codegen: 'loc()' and 'at()' for write in freedom block
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/extracted/test54.vyn
+++ b/test/units/extracted/test54.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test54.vyn
-// @test: Codegen: All pointer intrinsics used together in unsafe block
-// @description: Extracted from tests.cpp - Codegen: All pointer intrinsics used together in unsafe block
+// @test: Codegen: All pointer intrinsics used together in freedom block
+// @description: Extracted from tests.cpp - Codegen: All pointer intrinsics used together in freedom block
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/extracted/test55.vyn
+++ b/test/units/extracted/test55.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test55.vyn
-// @test: Semantic: Pointer operations require unsafe block - positive case
-// @description: Extracted from tests.cpp - Semantic: Pointer operations require unsafe block - positive case
+// @test: Semantic: Pointer operations require freedom block - positive case
+// @description: Extracted from tests.cpp - Semantic: Pointer operations require freedom block - positive case
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/extracted/test56.vyn
+++ b/test/units/extracted/test56.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test56.vyn
-// @test: Semantic: Pointer operations require unsafe block - negative case
-// @description: Extracted from tests.cpp - Semantic: Pointer operations require unsafe block - negative case
+// @test: Semantic: Pointer operations require freedom block - negative case
+// @description: Extracted from tests.cpp - Semantic: Pointer operations require freedom block - negative case
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/extracted/test_basic_pointer_operations_test.vyn
+++ b/test/units/extracted/test_basic_pointer_operations_test.vyn
@@ -11,7 +11,7 @@
 main()<Int> -> {
     x<Int> = 77;
     p<loc<Int>>;
-    unsafe {
+    freedom {
         p = loc(x);
         at(p) = 99;
     }

--- a/test/units/extracted/test_basic_pointer_operations_test_1.vyn
+++ b/test/units/extracted/test_basic_pointer_operations_test_1.vyn
@@ -11,7 +11,7 @@
 main()<Int> -> {
     x<Int> = 77;
     p<loc<Int>>;
-    unsafe {
+    freedom {
         p = loc(x);
         at(p) = 99;
     }

--- a/test/units/extracted/test_basic_pointer_operations_test_2.vyn
+++ b/test/units/extracted/test_basic_pointer_operations_test_2.vyn
@@ -11,7 +11,7 @@
 main()<Void> -> Int {
     x<Int> = 77;
     p<loc<Int>>;
-    unsafe {
+    freedom {
         p = loc(x);
         at(p) = 99;
     }

--- a/test/units/extracted/test_basic_pointer_operations_test_3.vyn
+++ b/test/units/extracted/test_basic_pointer_operations_test_3.vyn
@@ -11,7 +11,7 @@
 main()<Void> -> -> Int {
     x<Int> = 77;
     p<loc<Int>>;
-    unsafe {
+    freedom {
         p = loc(x);
         at(p) = 99;
     }

--- a/test/units/jit/test_basic_pointer_operations_test.vyn
+++ b/test/units/jit/test_basic_pointer_operations_test.vyn
@@ -10,7 +10,7 @@
 main()<Int> -> {
     x<Int> = 77;
     p<loc<Int>>;
-    unsafe {
+    freedom {
         p = loc(x);
         at(p) = 99;
     }

--- a/test/units/parser/test38.vyn
+++ b/test/units/parser/test38.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test38.vyn
-// @test: Semantic: from(addr) only allowed in unsafe
-// @description: Extracted from tests.cpp - Semantic: from(addr) only allowed in unsafe
+// @test: Semantic: from(addr) only allowed in freedom
+// @description: Extracted from tests.cpp - Semantic: from(addr) only allowed in freedom
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/parser/test39.vyn
+++ b/test/units/parser/test39.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test39.vyn
-// @test: Codegen: addr(loc) and from(addr) round-trip in unsafe
-// @description: Extracted from tests.cpp - Codegen: addr(loc) and from(addr) round-trip in unsafe
+// @test: Codegen: addr(loc) and from(addr) round-trip in freedom
+// @description: Extracted from tests.cpp - Codegen: addr(loc) and from(addr) round-trip in freedom
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/parser/test40.vyn
+++ b/test/units/parser/test40.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test40.vyn
-// @test: Parser: Basic unsafe block
-// @description: Extracted from tests.cpp - Parser: Basic unsafe block
+// @test: Parser: Basic freedom block
+// @description: Extracted from tests.cpp - Parser: Basic freedom block
 // @category: parser
 // @expect: pass
 // @parse-only: true
@@ -10,5 +10,5 @@
 
     std::string source = R"(
 main()<Void> -> -> Int{
-    unsafe {
+    freedom {
         x<Int> = 1;

--- a/test/units/parser/test41.vyn
+++ b/test/units/parser/test41.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test41.vyn
-// @test: Semantic: 'loc(var)' requires unsafe block
-// @description: Extracted from tests.cpp - Semantic: 'loc(var)' requires unsafe block
+// @test: Semantic: 'loc(var)' requires freedom block
+// @description: Extracted from tests.cpp - Semantic: 'loc(var)' requires freedom block
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/parser/test42.vyn
+++ b/test/units/parser/test42.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test42.vyn
-// @test: Semantic: 'at(loc_var)' (read) requires unsafe block
-// @description: Extracted from tests.cpp - Semantic: 'at(loc_var)' (read) requires unsafe block
+// @test: Semantic: 'at(loc_var)' (read) requires freedom block
+// @description: Extracted from tests.cpp - Semantic: 'at(loc_var)' (read) requires freedom block
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/parser/test43.vyn
+++ b/test/units/parser/test43.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test43.vyn
-// @test: Semantic: 'at(loc_var) = val' (write) requires unsafe block
-// @description: Extracted from tests.cpp - Semantic: 'at(loc_var) = val' (write) requires unsafe block
+// @test: Semantic: 'at(loc_var) = val' (write) requires freedom block
+// @description: Extracted from tests.cpp - Semantic: 'at(loc_var) = val' (write) requires freedom block
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/parser/test44.vyn
+++ b/test/units/parser/test44.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test44.vyn
-// @test: Semantic: 'from(addr_val)' requires unsafe block (already covered but good to be explicit)
-// @description: Extracted from tests.cpp - Semantic: 'from(addr_val)' requires unsafe block (already covered but good to be explicit)
+// @test: Semantic: 'from(addr_val)' requires freedom block (already covered but good to be explicit)
+// @description: Extracted from tests.cpp - Semantic: 'from(addr_val)' requires freedom block (already covered but good to be explicit)
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/parser/test45.vyn
+++ b/test/units/parser/test45.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test45.vyn
-// @test: Semantic: 'addr(loc_var)' is safe (does not require unsafe block)
-// @description: Extracted from tests.cpp - Semantic: 'addr(loc_var)' is safe (does not require unsafe block)
+// @test: Semantic: 'addr(loc_var)' is safe (does not require freedom block)
+// @description: Extracted from tests.cpp - Semantic: 'addr(loc_var)' is safe (does not require freedom block)
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/parser/test51.vyn
+++ b/test/units/parser/test51.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test51.vyn
-// @test: Codegen: 'loc()' and 'at()' for write in unsafe block
-// @description: Extracted from tests.cpp - Codegen: 'loc()' and 'at()' for write in unsafe block
+// @test: Codegen: 'loc()' and 'at()' for write in freedom block
+// @description: Extracted from tests.cpp - Codegen: 'loc()' and 'at()' for write in freedom block
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/parser/test54.vyn
+++ b/test/units/parser/test54.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test54.vyn
-// @test: Codegen: All pointer intrinsics used together in unsafe block
-// @description: Extracted from tests.cpp - Codegen: All pointer intrinsics used together in unsafe block
+// @test: Codegen: All pointer intrinsics used together in freedom block
+// @description: Extracted from tests.cpp - Codegen: All pointer intrinsics used together in freedom block
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/parser/test55.vyn
+++ b/test/units/parser/test55.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test55.vyn
-// @test: Semantic: Pointer operations require unsafe block - positive case
-// @description: Extracted from tests.cpp - Semantic: Pointer operations require unsafe block - positive case
+// @test: Semantic: Pointer operations require freedom block - positive case
+// @description: Extracted from tests.cpp - Semantic: Pointer operations require freedom block - positive case
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/parser/test56.vyn
+++ b/test/units/parser/test56.vyn
@@ -1,6 +1,6 @@
 // filepath: /home/rick/Projects/Vyn/test/units/extracted/test56.vyn
-// @test: Semantic: Pointer operations require unsafe block - negative case
-// @description: Extracted from tests.cpp - Semantic: Pointer operations require unsafe block - negative case
+// @test: Semantic: Pointer operations require freedom block - negative case
+// @description: Extracted from tests.cpp - Semantic: Pointer operations require freedom block - negative case
 // @category: parser
 // @expect: pass
 // @parse-only: true

--- a/test/units/test50.vyn
+++ b/test/units/test50.vyn
@@ -2,7 +2,7 @@
 main()<Int> -> {
     x<my<Int>> = 10;
     
-    unsafe {
+    freedom {
         // Test borrow shorthand for mutable borrow
         b<their<Int>> = borrow x;
         b = 20; // Modify through the borrow

--- a/test/units/test51.vyn
+++ b/test/units/test51.vyn
@@ -1,9 +1,9 @@
-//# EXPECTED ERROR: borrow() can only be used inside an unsafe block
+//# EXPECTED ERROR: borrow() can only be used inside an freedom block
 
 main()<Int> -> {
     x<my<Int>> = 10;
     
-    // Using borrow outside unsafe block should fail
+    // Using borrow outside freedom block should fail
     b<their<Int>> = borrow x;
     b = 20;
     

--- a/test/units/test52.vyn
+++ b/test/units/test52.vyn
@@ -1,4 +1,4 @@
-//# EXPECTED ERROR: view() can only be used inside an unsafe block
+//# EXPECTED ERROR: view() can only be used inside an freedom block
 
 main()<Int> -> {
     x<my<Int>> = 10;

--- a/test/units/test53.vyn
+++ b/test/units/test53.vyn
@@ -3,7 +3,7 @@
 main()<Int> -> {
     x<Int> = 10; // Not an owned type (missing my<> or our<>)
     
-    unsafe {
+    freedom {
         // Using borrow on non-owned type should fail
         b<their<Int>> = borrow x;
         b = 20;

--- a/test/units/test_semantic_fix.vyn
+++ b/test/units/test_semantic_fix.vyn
@@ -1,6 +1,6 @@
 main()<Int> -> {
     x<Float>; // x is Float
-    unsafe {
+    freedom {
         p<loc<Int>> = loc(x); // Error: trying to get loc<Int> from Float
     }
     return 0;


### PR DESCRIPTION
🇺🇸 MAJOR IDEOLOGICAL UPGRADE 🇺��

Replaced oppressive 'unsafe' keyword with liberating 'freedom' keyword!

Changes:
- Renamed KEYWORD_UNSAFE → KEYWORD_FREEDOM in all source files
- Updated lexer to recognize 'freedom' keyword
- Updated all freedom blocks: freedom { ... }
- Updated parser to expect 'freedom' token
- Updated AST: FreedomStatement (was FreedomStatement)
- Updated semantic analyzer: isInFreedomBlock()
- Updated all error messages: 'freedom block' instead of 'freedom block'
- Updated all documentation and comments

Philosophy:
Vyn embraces FREEDOM over safety! freedom blocks let you be FREE! Trade safety for LIBERTY! 🦅

Examples:
  freedom {
      ptr<loc<Int>> = loc(variable)
      at(ptr) = 99
  }

All tests pass with freedom blocks working correctly!

This is America! We choose FREEDOM! 🎆