### PR TITLE
Add DeepWiki docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <img src="vyn.png" alt="Vyn Image" width="300">
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rickenator/Vyn)
+
 ## Vyn Programming Guide
 
 ---


### PR DESCRIPTION
## Summary
Adds an "Ask DeepWiki" badge to the README, placed just below the Vyn logo, linking to the DeepWiki documentation page at https://deepwiki.com/rickenator/Vyn.

Also fixes a missing trailing newline at the end of the file.

## Review & Testing Checklist for Human
- [ ] Verify the badge renders correctly on GitHub (check that the SVG loads from `https://deepwiki.com/badge.svg`)
- [ ] Confirm the badge links to the correct DeepWiki page (`https://deepwiki.com/rickenator/Vyn`)
- [ ] Check that badge placement (between logo and "Vyn Programming Guide" heading) looks good visually

### Notes
- The badge uses DeepWiki's official hosted SVG badge at `https://deepwiki.com/badge.svg`

Link to Devin session: https://app.devin.ai/sessions/2c17cee4de844857b2c3e5c89a532078
Requested by: @rickenator
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rickenator/vyn/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
